### PR TITLE
Non-max suppression applied in inference.py

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -11,6 +11,7 @@ import torch
 from datasets import AirbusShipDetection
 from imageutils import draw_image_with_boxes
 from transforms import ToTensor
+from torchvision.ops import nms
 
 # Input folder with images to classify.
 IMAGES_IN = 'sentinel-hub'

--- a/inference.py
+++ b/inference.py
@@ -110,9 +110,14 @@ for fn in fn_images:
             tgt_pred = model(x_tensor)
             tgt_pred = tgt_pred[0]
 
-            # Get the boxes and apply the cropping offset.
-            boxes = tgt_pred['boxes'].detach().cpu().numpy()
-            for box in boxes:
+            # Get the boxes and apply the cropping offset + Applying Non-max suppression
+            boxes = tgt_pred['boxes'].detach().cpu()    #I_added
+            scores= tgt_pred['scores'].detach().cpu()   #I_added
+            nms_result = nms(boxes=boxes, scores=scores, iou_threshold=iou_threshold)
+            boxes = boxes.numpy() 
+            boxes_nms = []
+            boxes_nms = [boxes[i] for i in nms_result]
+            for box in boxes_nms:
 
                 # Threshold on area.
                 # Maximum area: 360 * 50 m = 18000 m2 = 180 pixels.


### PR DESCRIPTION
To prevent the model from detecting a ship multiple times, non-maximum suppression is implemented in the inference.py code using the torchvision library.